### PR TITLE
make MapDependencyGraph into a record for easier printing and general use

### DIFF
--- a/src/com/stuartsierra/dependency.clj
+++ b/src/com/stuartsierra/dependency.clj
@@ -56,7 +56,7 @@
 (def ^:private set-conj (fnil conj #{}))
 
 ;; Do not construct directly, use 'graph' function
-(deftype MapDependencyGraph [dependencies dependents]
+(defrecord MapDependencyGraph [dependencies dependents]
   DependencyGraph
   (immediate-dependencies [graph node]
     (get dependencies node #{}))


### PR DESCRIPTION
It looks like `tools.namespace` made [the same change](https://github.com/clojure/tools.namespace/commit/5808dc124c7bf0cfc06c2c84ab2c1e16cc9d6cea) as well.  Any objections to having this be a record?