### PR TITLE
Replace lazy concat call

### DIFF
--- a/src/com/stuartsierra/dependency.cljc
+++ b/src/com/stuartsierra/dependency.cljc
@@ -58,7 +58,7 @@
     (if-let [[node & more] (seq unexpanded)]
       (if (contains? expanded node)
         (recur more expanded)
-        (recur (concat more (neighbors node))
+        (recur (into more (neighbors node))
                (conj expanded node)))
       expanded)))
 


### PR DESCRIPTION
This is a fantastic library and we've been using it in a project that generates large graphs on Clojure and Clojurescript. However, under Clojurescript, running in the browser using advanced compilation we get 'Maximum call stack size exceeded' errors when building our graphs and the error messages point to the lazy `concat` call inside the `transitive` function. Replacing with `into` resolves this issue.

