### PR TITLE
Optimise topo-sort.

### DIFF
--- a/src/com/stuartsierra/dependency.cljc
+++ b/src/com/stuartsierra/dependency.cljc
@@ -143,7 +143,11 @@
                          [add g]))]
         (recur (cons node sorted)
                (remove-node g' node)
-               (clojure.set/union (set more) (set add)))))))
+               ;; NOTE: dep/topo-sort:master creates set from more and add
+               ;; this seems to take much longer than a simple union
+               ;; on more and add.
+               ;; more and add are guaranteed to be sets by the above code.
+               (clojure.set/union more add))))))
 
 (def ^:private max-number
   #?(:clj Long/MAX_VALUE


### PR DESCRIPTION
Avoid creating sets in the recur. This seems to save around 3 seconds for a graph with about 8k nodes.